### PR TITLE
More informative docker logs output

### DIFF
--- a/start_mariadb.sh
+++ b/start_mariadb.sh
@@ -7,7 +7,7 @@ if [[ ! -f /opt/mysql/initialized ]]; then
     chmod -R 755 /opt/mysql
 fi
 sleep 2
-mysqld_safe &
+mysqld_safe --skip-syslog --log-error=/var/log/mysql.err &
 sleep 8
 if [[ ! -f /opt/mysql/initialized ]]; then
     echo "CREATE DATABASE db;" | mysql -u root --password=a_stronk_password
@@ -15,4 +15,4 @@ if [[ ! -f /opt/mysql/initialized ]]; then
     echo "GRANT ALL ON *.* to root@'%' IDENTIFIED BY '$1'; FLUSH PRIVILEGES;" | mysql -u root --password="$1" mysql
     touch /opt/mysql/initialized
 fi
-tailf /var/log/mysql.log
+tail -f /var/log/mysql.log /var/log/mysql.err


### PR DESCRIPTION
Example log output with the modifications in this pr:

```
$ docker logs <container-id>
==> db: 140620 11:58:06 mysqld_safe Logging to '/var/log/mysql.err'.
==> db: 140620 11:58:06 mysqld_safe Starting mysqld daemon with databases from /opt/mysql
==> db: ==> /var/log/mysql.log <==
==> db:
==> db: ==> /var/log/mysql.err <==
==> db: InnoDB: Restoring possible half-written data pages from the doublewrite
==> db: InnoDB: buffer...
==> db: InnoDB: Last MySQL binlog file position 0 1250803, file name /var/log/mysql/mariadb-bin.000007
==> db: 140620 11:58:06  InnoDB: Waiting for the background threads to start
==> db: 140620 11:58:07 Percona XtraDB (http://www.percona.com) 5.5.37-MariaDB-35.0 started; log sequence number 26584403
==> db: 140620 11:58:07 [Note] Plugin 'FEEDBACK' is disabled.
==> db: 140620 11:58:07 [Note] Server socket created on IP: '0.0.0.0'.
==> db: 140620 11:58:07 [Note] Event Scheduler: Loaded 0 events
==> db: 140620 11:58:07 [Note] /usr/sbin/mysqld: ready for connections.
==> db: Version: '5.5.38-MariaDB-1~quantal-log'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  mariadb.org binary distribution
```
