### PR TITLE
Fixed database initialization

### DIFF
--- a/start_mariadb.sh
+++ b/start_mariadb.sh
@@ -8,7 +8,8 @@ if [[ ! -f /opt/mysql/initialized ]]; then
 fi
 sleep 2
 mysqld_safe --skip-syslog --log-error=/var/log/mysql.err &
-sleep 8
+# Wait for socket to be ready
+while [ ! -S /var/run/mysqld/mysqld.sock ]; do sleep 1; done
 if [[ ! -f /opt/mysql/initialized ]]; then
     echo "CREATE DATABASE db;" | mysql -u root --password=a_stronk_password
     echo "UPDATE mysql.user SET Password=PASSWORD('$1') WHERE User='root'; FLUSH PRIVILEGES;" | mysql -u root --password=a_stronk_password mysql


### PR DESCRIPTION
Hi,

you have hardcoded sleep 8 at https://github.com/Kloadut/dokku-md-dockerfiles/blob/master/start_mariadb.sh#L11

This is not good solution, because when the machine is currently slower, the password will not be set and next commands will print:
`ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock'`
because the server is not ready.

Instead of hardcoded 8s sleep I used sleep loop which detects when the connection can be made
