### PR TITLE
Upgrade to a LTS release (trusty 14.04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM	ubuntu:trusty
 MAINTAINER	kload "kload@kload.fr"
 
 # prevent apt from starting mariadb right after the installation
-RUN	echo "#!/bin/sh\nexit 101" > /usr/sbin/policy-rc.d; chmod +x /usr/sbin/policy-rc.d
+RUN	printf '#!/bin/sh\nexit 101' > /usr/sbin/policy-rc.d; chmod +x /usr/sbin/policy-rc.d
 
 RUN apt-get update
 RUN apt-get install -y software-properties-common

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER	kload "kload@kload.fr"
 # prevent apt from starting mariadb right after the installation
 RUN	echo "#!/bin/sh\nexit 101" > /usr/sbin/policy-rc.d; chmod +x /usr/sbin/policy-rc.d
 
-RUN sed -i s/archive/old-releases/g /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y software-properties-common
 RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM	ubuntu:quantal
+FROM	ubuntu:trusty
 MAINTAINER	kload "kload@kload.fr"
 
 # prevent apt from starting mariadb right after the installation
@@ -8,7 +8,7 @@ RUN sed -i s/archive/old-releases/g /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install -y software-properties-common
 RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db
-RUN add-apt-repository 'deb http://archive.mariadb.org/mariadb-5.5.38/repo/ubuntu/ quantal main'
+RUN add-apt-repository 'deb http://ftp.osuosl.org/pub/mariadb/repo/5.5/ubuntu trusty main'
 RUN apt-get update
 RUN echo mysql-server-5.5 mysql-server/root_password password 'a_stronk_password' | debconf-set-selections
 RUN echo mysql-server-5.5 mysql-server/root_password_again password 'a_stronk_password' | debconf-set-selections


### PR DESCRIPTION
Using ubuntu:trusty as base image since mariadb ppa no longer supports quantal (eol)

Changing the repo url (#5) must only be considered a workaround since Quantal is not supported anymore (that mariadb archive server has a very low bandwidth it seems as well). The only real solution is to use Ubuntu Trusty going forward. I recently attempted this in https://github.com/motin/dokku-md-dockerfiles/tree/upgrade-to-trusty
