### PR TITLE
Showing what commands are run to start the container

### DIFF
--- a/start_mariadb.sh
+++ b/start_mariadb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -x
 if [[ ! -f /opt/mysql/initialized ]]; then
     mkdir -p /opt/mysql
     cp -a /var/lib/mysql/* /opt/mysql/


### PR DESCRIPTION
greatly eases debugging problems during start-up
